### PR TITLE
Feature/refactor

### DIFF
--- a/MongoDbChecker/MongoDbChecker.go
+++ b/MongoDbChecker/MongoDbChecker.go
@@ -10,6 +10,8 @@ import (
 	"wait4it/model"
 )
 
+const WaitTimeOutSeconds = 2
+
 func (m *MongoDbConnection) BuildContext(cx model.CheckContext) {
 	m.Port = cx.Port
 	m.Host = cx.Host
@@ -40,7 +42,7 @@ func (m *MongoDbConnection) Check() (bool, bool, error) {
 		return false, true, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), WaitTimeOutSeconds*time.Second)
 	defer cancel()
 
 	err = client.Connect(ctx)

--- a/PostgreSQLChecker/postgresqlChecker.go
+++ b/PostgreSQLChecker/postgresqlChecker.go
@@ -26,7 +26,7 @@ func (pq *PostgresSQLConnection) Validate() (bool, error) {
 	}
 
 	if pq.Port < 0 || pq.Port > 65535 {
-		return false, errors.New("invalid port range for mysql")
+		return false, errors.New("invalid port range for PostgresSQL")
 	}
 
 	return true, nil

--- a/cmd/check-cmd.go
+++ b/cmd/check-cmd.go
@@ -8,11 +8,13 @@ import (
 	"wait4it/model"
 )
 
+const InvalidUsageStatus = 2
+
 func RunCheck(c model.CheckContext) {
 	m, err := findCheckModule(c.Config.CheckType)
 	if err != nil {
 		wStdErr(err)
-		os.Exit(2)
+		os.Exit(InvalidUsageStatus)
 	}
 
 	cx := m.(model.CheckInterface)
@@ -21,7 +23,7 @@ func RunCheck(c model.CheckContext) {
 	r, err := cx.Validate()
 	if !r {
 		wStdErr(err)
-		os.Exit(2)
+		os.Exit(InvalidUsageStatus)
 	}
 
 	fmt.Print("Wait4it...")
@@ -62,7 +64,7 @@ func check(cs model.CheckInterface) {
 	r, eor, err := cs.Check()
 	if err != nil && eor {
 		wStdErr(err.Error())
-		os.Exit(2)
+		os.Exit(InvalidUsageStatus)
 	}
 
 	wStdOut(r)

--- a/httpChecker/httpChecker.go
+++ b/httpChecker/httpChecker.go
@@ -34,6 +34,7 @@ func (h *HttpCheck) Check() (bool, bool, error) {
 	if err != nil {
 		return false, true, err
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Found some warnings in linters. A tiny refactor with love xD

- HTTP body must be closed
- It's considered a bad programming practice to use numbers directly in any source code without an explanation. It makes programs harder to read, understand, and maintain.
- Used word `mysql` in a Postgres error string
