### PR TITLE
Read password value from env if the cli arg is empty

### DIFF
--- a/cmd/wait4it/main.go
+++ b/cmd/wait4it/main.go
@@ -52,7 +52,7 @@ func main() {
 	flag.StringVar(&cfg.Host, "h", defaultEnv("W4IT_HOST", "127.0.0.1"), "IP of the host you want to test against")
 	flag.IntVar(&cfg.Port, "p", defaultEnvInt("W4IT_PORT", 0), "Port")
 	flag.StringVar(&cfg.Username, "u", defaultEnv("W4IT_USERNAME", ""), "Username of the service")
-	flag.StringVar(&cfg.Password, "P", "", "Password of the service, it picks the W4IT_PASSWORD env if it is empty")
+	flag.StringVar(&cfg.Password, "P", defaultEnv("W4IT_PASSWORD", ""), "Password of the service, it picks the W4IT_PASSWORD env if it is empty")
 	flag.StringVar(&cfg.DatabaseName, "n", defaultEnv("W4IT_DBNAME", ""), "Name of the database")
 	flag.StringVar(&cfg.DBConf.SSLMode, "ssl", defaultEnv("W4IT_SSL_MODE", "disable"), "Enable or Disable ssl mode (for some database or services)")
 	flag.StringVar(&cfg.DBConf.OperationMode, "operation-mode", defaultEnv("W4IT_OPERATION_MODE", "standalone"), "choose operation mode (for some database or services)")


### PR DESCRIPTION
As the document stated, the app will read the password from `W4IT_PASSWORD` environment variable