### PR TITLE
Add tests for the Docker image

### DIFF
--- a/.github/workflows/integrations-app.yaml
+++ b/.github/workflows/integrations-app.yaml
@@ -1,4 +1,4 @@
-name: Integrations tests
+name: Integrations tests (App)
 on: push
 
 jobs:

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v3
       - name: Build and cache
         uses: docker/build-push-action@v3
         with:
@@ -38,7 +39,7 @@ jobs:
           tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - uses: actions/checkout@v3
+
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1
       - name: Test TCP

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -47,6 +47,9 @@ jobs:
           docker image ls -a
           docker network ls
           docker ps -a
+          docker network create app
+          docker network connect app redis
+          docker network inspect app
 
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=redis

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -1,0 +1,35 @@
+name: Integrations tests (Docker)
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and cache
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  redis-tcp:
+    runs-on: ubuntu-latest
+    needs: build
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+    steps:
+      - name: Retrieve wait4it
+        uses: actions/cache@v3
+        with:
+          path: wait4it
+          key: wait4it-${{ github.run_id }}
+      - name: Test Redis
+        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1
+      - name: Test TCP
+        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=tcp -h=127.0.0.1 -p=6379 -t=60
+

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Load Docker image
         run: |
-          docker load --input docker-image.tar
+#          docker load --input docker-image.tar
           docker image ls -a
           docker network ls
           docker ps -a

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -14,3 +14,5 @@ jobs:
         run: docker compose run test-redis
       - name: TCP test
         run: docker compose run test-tcp
+      - name: PostgreSQL test
+        run: docker compose run test-postgres

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -27,11 +27,14 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - name: Retrieve wait4it
-        uses: actions/cache@v3
+      - name: Build and cache
+        uses: docker/build-push-action@v3
         with:
-          path: wait4it
-          key: wait4it-${{ github.run_id }}
+          context: .
+          push: false
+          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1
       - name: Test TCP

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -2,55 +2,15 @@ name: Integrations tests (Docker)
 on: push
 
 jobs:
-  build:
+  docker-image-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-#      - name: Build and cache
-#        uses: docker/build-push-action@v3
-#        with:
-#          context: .
-#          push: false
-#          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
-#          outputs: type=docker,dest=docker-image.tar
-#
-#      - name: Cache wait4it docker image
-#        uses: actions/cache@v3
-#        with:
-#          path: docker-image.tar
-#          key: wait4it-docker-${{ github.run_id }}
-#          restore-keys: wait4it-docker-${{ github.run_id }}
-
-  redis-tcp:
-    runs-on: ubuntu-latest
-    needs: build
-#    services:
-#      redis:
-#        image: redis
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Retrieve wait4it docker image
-        uses: actions/cache@v3
-        with:
-          path: docker-image.tar
-          key: wait4it-docker-${{ github.run_id }}
-
-      - name: Load Docker image
-        run: |
-          # docker load --input docker-image.tar
-          #docker image ls -a
-          docker run --network=app --name=redis redis:latest
-          docker network ls
-          docker network inspect app
-
-      - name: Test Redis
-        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=redis
-      - name: Test TCP
-        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=tcp -h=redis -p=6379 -t=60
-
+      - name: Build images
+        run: docker compose build
+      - name: Redis Test
+        run: docker compose run test-redis
+      - name: TCP test
+        run: docker compose run test-tcp

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -5,6 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -15,8 +15,14 @@ jobs:
           context: .
           push: false
           tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=docker-image.tar
+
+      - name: Cache wait4it docker image
+        uses: actions/cache@v3
+        with:
+          path: docker-image.tar
+          key: wait4it-docker-${{ github.run_id }}
+          restore-keys: wait4it-docker
 
   redis-tcp:
     runs-on: ubuntu-latest
@@ -29,16 +35,17 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
-      - name: Build and cache
-        uses: docker/build-push-action@v3
+
+      - name: Retrieve wait4it docker image
+        uses: actions/cache@v3
         with:
-          context: .
-          push: false
-          load: true
-          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: docker-image.tar
+          key: wait4it-docker-${{ github.run_id }}
+
+      - name: Load Docker image
+        run: |
+          docker load --input docker-image.tar
+          docker image ls -a
 
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -5,6 +5,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build and cache
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: docker-image.tar
           key: wait4it-docker-${{ github.run_id }}
-          restore-keys: wait4it-docker
+          restore-keys: wait4it-docker-${{ github.run_id }}
 
   redis-tcp:
     runs-on: ubuntu-latest

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -9,20 +9,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and cache
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
-          outputs: type=docker,dest=docker-image.tar
-
-      - name: Cache wait4it docker image
-        uses: actions/cache@v3
-        with:
-          path: docker-image.tar
-          key: wait4it-docker-${{ github.run_id }}
-          restore-keys: wait4it-docker-${{ github.run_id }}
+#      - name: Build and cache
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: .
+#          push: false
+#          tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
+#          outputs: type=docker,dest=docker-image.tar
+#
+#      - name: Cache wait4it docker image
+#        uses: actions/cache@v3
+#        with:
+#          path: docker-image.tar
+#          key: wait4it-docker-${{ github.run_id }}
+#          restore-keys: wait4it-docker-${{ github.run_id }}
 
   redis-tcp:
     runs-on: ubuntu-latest
@@ -45,6 +45,8 @@ jobs:
         run: |
           docker load --input docker-image.tar
           docker image ls -a
+          docker network ls
+          docker ps -a
 
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=redis

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -27,6 +27,8 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and cache
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Load Docker image
         run: |
-#          docker load --input docker-image.tar
+          # docker load --input docker-image.tar
           docker image ls -a
           docker network ls
           docker ps -a

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -37,6 +37,7 @@ jobs:
           tags: "ph4r5h4d/wait4it:${{ github.run_id }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - uses: actions/checkout@v3
       - name: Test Redis
         run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1
       - name: Test TCP

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -30,8 +30,7 @@ jobs:
     services:
       redis:
         image: redis
-        ports:
-          - 6379:6379
+
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -48,7 +47,7 @@ jobs:
           docker image ls -a
 
       - name: Test Redis
-        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=127.0.0.1
+        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=redis -p=6379 -t=60 -h=redis
       - name: Test TCP
-        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=tcp -h=127.0.0.1 -p=6379 -t=60
+        run: docker run ph4r5h4d/wait4it:${{ github.run_id }} -type=tcp -h=redis -p=6379 -t=60
 

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -27,9 +27,9 @@ jobs:
   redis-tcp:
     runs-on: ubuntu-latest
     needs: build
-    services:
-      redis:
-        image: redis
+#    services:
+#      redis:
+#        image: redis
 
     steps:
       - name: Set up Docker Buildx
@@ -44,11 +44,9 @@ jobs:
       - name: Load Docker image
         run: |
           # docker load --input docker-image.tar
-          docker image ls -a
+          #docker image ls -a
+          docker run --network=app --name=redis redis:latest
           docker network ls
-          docker ps -a
-          docker network create app
-          docker network connect app redis
           docker network inspect app
 
       - name: Test Redis

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,14 @@ WORKDIR $GOPATH/src/github.com/ph4r5h4d/wait4it
 COPY . .
 RUN go mod download
 RUN go mod verify
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/wait4it
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/wait4it
 RUN chown appuser:appuser /go/bin/wait4it
 
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/bin/wait4it wait4it
+COPY --from=builder /go/bin/wait4it /wait4it
 
 USER appuser:appuser
-CMD ["/wait4it"]
+ENTRYPOINT ["/wait4it"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/bin/wait4it /go/bin/wait4it
+COPY --from=builder /go/bin/wait4it wait4it
 
 USER appuser:appuser
-ENTRYPOINT ["/go/bin/wait4it"]
+ENTRYPOINT ["./wait4it"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY . .
 RUN go mod download
 RUN go mod verify
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/wait4it
+RUN chown appuser:appuser /go/bin/wait4it
 
 FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM scratch
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/bin/wait4it /wait4it
+COPY --from=builder /go/bin/wait4it /go/bin/wait4it
 
 USER appuser:appuser
-ENTRYPOINT ["/wait4it"]
+ENTRYPOINT ["/go/bin/wait4it"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/wait4it wait4it
 
 USER appuser:appuser
-ENTRYPOINT ["./wait4it"]
+CMD ["/wait4it"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  redis:
+    image: redis:latest
+
+  test-redis:
+    build: .
+    command: -type=redis -p=6379 -t=60 -h=redis
+    depends_on:
+      - redis
+
+  test-tcp:
+    build: .
+    command: -type=tcp -h=redis -p=6379 -t=60
+    depends_on:
+      - redis
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,35 @@
 version: "3"
 services:
+  build:
+    build: .
+    image: wait4it-pipeline/docker:latest
+
   redis:
     image: redis:latest
 
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: postgres
+
   test-redis:
-    build: .
+    image: wait4it-pipeline/docker:latest
     command: -type=redis -p=6379 -t=60 -h=redis
     depends_on:
+      - build
       - redis
 
   test-tcp:
-    build: .
+    image: wait4it-pipeline/docker:latest
     command: -type=tcp -h=redis -p=6379 -t=60
     depends_on:
+      - build
       - redis
+
+  test-postgres:
+    image: wait4it-pipeline/docker:latest
+    command: -type=postgres -h=postgres -p=5432 -t=60 -u=postgres -P=postgres -ssl=disable
+    depends_on:
+      - build
+      - postgres
 


### PR DESCRIPTION
Since wait4it is going to be shipped within the scratch image, it makes sense to make sure on every build we test the app binary and the docker image to make sure it works perfectly on both environment.