### PR TITLE
Add "Powered by GoLand" section to README and index documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ For detailed installation instructions, visit the [installation doc](https://wai
 
 ## Documentation
 Visit the [website](https://wait4it.dev) for detailed documentation.
+
+### Powered by
+[![GoLand logo.](https://resources.jetbrains.com/storage/products/company/brand/logos/GoLand.svg)](https://jb.gg/OpenSourceSupport)

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -41,3 +41,6 @@ This approach ensures smooth service synchronization while leaving orchestration
 ## Get Started with Wait4it
 
 Say goodbye to failed startups and hello to readiness. Whether in development or production, Wait4it is your go-to solution for ensuring service health with minimal effort.
+
+### Powered by
+[![GoLand logo.](https://resources.jetbrains.com/storage/products/company/brand/logos/GoLand.svg)](https://jb.gg/OpenSourceSupport)


### PR DESCRIPTION
This pull request adds a "Powered by" section to the documentation, acknowledging the use of JetBrains GoLand under their Open Source Support program.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R32): Added a "Powered by" section with the GoLand logo and a link to JetBrains Open Source Support.
* [`docs/content/_index.md`](diffhunk://#diff-5d9ba8bc1a568741b44ccc852748ca739d71f89dc1ac05a9f8d3787a064a549dR44-R46): Added a "Powered by" section with the GoLand logo and a link to JetBrains Open Source Support.