### PR TITLE
chore: add org.opencontainers.image.source label for Renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
+
 FROM golang:1.23-alpine as builder
 RUN apk update && apk add --no-cache gcc git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
-
 FROM golang:1.23-alpine as builder
 RUN apk update && apk add --no-cache gcc git
 
@@ -22,6 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/w
 RUN chown appuser:appuser /go/bin/wait4it
 
 FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 FROM golang:1.23-alpine as build-env
 RUN apk add git gcc
 RUN mkdir /app

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,4 @@
 FROM golang:1.23-alpine as build-env
-LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 RUN apk add git gcc
 RUN mkdir /app
 WORKDIR /app
@@ -8,6 +7,7 @@ RUN go mod download
 RUN go mod verify
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o wait4it
 FROM alpine:3.17
+LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 COPY --from=build-env /app/wait4it .
 USER 1001
 ENTRYPOINT ["./wait4it"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
-LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 FROM golang:1.23-alpine as build-env
+LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 RUN apk add git gcc
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
This pull request adds metadata to the `Dockerfile` and `Dockerfile.alpine` to include the source repository information. This change improves traceability and compliance with container image standards.

Metadata updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R2): Added a `LABEL` to specify the source repository URL (`https://github.com/ph4r5h4d/wait4it`).
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eR1): Added a `LABEL` with the same source repository URL for consistency.