### PR TITLE
Add opencontainer.revision label to published images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build docker image
-      run: docker build . --file Dockerfile --tag wait4it
+      run: |
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        docker build . --file Dockerfile --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
     - name: Logging into docker hub
       run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
     - name: Tag and push
@@ -38,7 +41,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build docker image
-      run: docker build . --file Dockerfile.alpine --tag wait4it
+      run: |
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        docker build . --file Dockerfile.alpine --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
     - name: Logging into docker hub
       run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
     - name: Tag and push


### PR DESCRIPTION
Hi, it's me again! Thank you for implementing https://github.com/ph4r5h4d/wait4it/issues/170, but unfortunately this doesn't work :(

After looking at the Renovate source code, I am pretty sure that Renovate just isn't smart enough to automatically drop the "platform identifier suffix" from the image tag (`-scratch` or `-alpine`) when fetching the release notes.

According to https://docs.renovatebot.com/modules/datasource/docker/, Renovate honors the annotation/label `org.opencontainers.image.revision` to extract the git-ref from the image.

This PR is a proposal how you could add this label.

---

Slightly off-topic: Actually, "annotations" and "labels" are not the same. The `org.opencontainers` annotations are actually designed to be used as *annotations*, which are specified by the OCI spec. The Docker image format doesn't allow annotations, but uses "labels" instead. Annotations are stored directly inside the image manifest, while labels are stored inside the "config" layer. Renovate first looks for "annotations" and then falls back to "labels".

You can't add *annotations* when building an image using a `Dockerfile`, but you can add annotations via `docker buildx build --annotation`. In recent Docker versions `buildx` has been made the default builder, so in recent Docker versions you can just use `docker build --annotation` just as I used `docker build --label` in this PR. I don't know if the Docker version used in this GitHub workflow is recent enough, so I used `--label` in this PR.

I am telling you this because *if* you can use `docker build --annotation` here, then you probably should do so for both labels. Renovate doesn't care either way, but the OCI Image spec clearly defines these keys as **annotations**: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

For reference: https://docs.docker.com/build/metadata/annotations/