### PR TITLE
Feature/add oracle support

### DIFF
--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -300,6 +300,27 @@ jobs:
       - name: Kafka Test
         run: docker compose run test-kafka
 
+  Oracle:
+    runs-on: ubuntu-latest
+    needs: Build
+    env:
+      PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v3
+      - name: Retrieve wait4it
+        uses: actions/cache@v3
+        with:
+          path: wait4it.tar
+          key: wait4it-docker-${{ github.run_id }}
+      - name: Load image into docker
+        run: docker load --input wait4it.tar
+      - name: List images
+        run: docker image ls
+      - name: Oracle Test
+        run: docker compose run test-oracle
+
   DNS:
     runs-on: ubuntu-latest
     needs: Build

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It also supports **timeout** so it can wait for a particular time and then fail.
 * [PostgresQL](https://wait4it.dev/docs/postgresql/)
 * [Http](https://wait4it.dev/docs/http/)
 * [MongoDB](https://wait4it.dev/docs/mongodb/)
+* [Oracle](https://wait4it.dev/docs/oracle/)
 * [Redis](https://wait4it.dev/docs/redis/)
 * [RabbitMQ](https://wait4it.dev/docs/rabbitmq/)
 * [Memcached](https://wait4it.dev/docs/memcached/)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -177,3 +177,23 @@ services:
       - build
       - dnsmasq
 
+  oracle:
+    image: gvenzl/oracle-free:slim-faststart
+    environment:
+      ORACLE_PASSWORD: secret
+      APP_USER: app
+      APP_USER_PASSWORD: secret
+    healthcheck:
+      test: ["CMD", "healthcheck.sh"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  test-oracle:
+    image: wait4it-pipeline/docker:${PIPELINE_IMAGE_VERSION:-latest}
+    command: -type=oracle -h=oracle -p=1521 -t=30 -u=app -P=secret -n=FREEPDB1
+    depends_on:
+      - build
+      - oracle
+

--- a/docs/content/docs/Oracle/_index.md
+++ b/docs/content/docs/Oracle/_index.md
@@ -1,0 +1,58 @@
++++
+date = '2026-05-27T12:00:00+00:00'
+draft = false
+title = 'Oracle Check'
++++
+
+Oracle Check validates connectivity to an Oracle Database (21c and higher, including 23ai) using a service name (typically a PDB such as `FREEPDB1`).
+
+## Usage with Binary
+```bash
+./wait4it -type=oracle -h=127.0.0.1 -p=1521 -t=60 -u=app -P=secret -n=FREEPDB1
+```
+
+## Usage with Docker
+```bash
+docker run ph4r5h4d/wait4it -type=oracle -h=127.0.0.1 -p=1521 -t=60 -u=app -P=secret -n=FREEPDB1
+```
+
+## Environment Variables
+
+| Variable           | Description                                                              | Default   |
+|--------------------|--------------------------------------------------------------------------|-----------|
+| W4IT_TYPE          | The type of check (set to `oracle` for Oracle check).                    | -         |
+| W4IT_TIMEOUT       | Timeout in seconds.                                                      | 30        |
+| W4IT_HOST          | The host to check.                                                       | 127.0.0.1 |
+| W4IT_PORT          | The port to check on the Oracle host (default Oracle listener port).     | 1521      |
+| W4IT_USERNAME      | The username for Oracle authentication.                                  | -         |
+| W4IT_PASSWORD      | The password for Oracle authentication.                                  | -         |
+| W4IT_PASSWORD_FILE | The file with password for Oracle authentication.                        | -         |
+| W4IT_DBNAME        | The service name (or PDB name, e.g. `FREEPDB1` or `XEPDB1`) to connect to. | -         |
+
+## Command-Line Arguments
+
+| Argument | Description                                                              | Default   |
+|----------|--------------------------------------------------------------------------|-----------|
+| -type    | The type of check (set to `oracle`).                                     | -         |
+| -t       | Timeout in seconds.                                                      | 30        |
+| -h       | The host to check.                                                       | 127.0.0.1 |
+| -p       | The port to check on the Oracle host.                                    | 1521      |
+| -u       | The username for Oracle authentication.                                  | -         |
+| -P       | The password for Oracle authentication.                                  | -         |
+| -Pf      | The file with password for Oracle authentication.                        | -         |
+| -n       | The service name / PDB name to connect to (recommended for 21c+).        | -         |
+
+## Notes
+{{< callout type="info" >}}
+- Environment variables override command-line arguments.
+- For Oracle 21c and higher (including 23ai Free / XE), use the PDB service name in `-n` / `W4IT_DBNAME` (commonly `FREEPDB1` with popular container images such as `gvenzl/oracle-free` or `gvenzl/oracle-xe`).
+- The check performs a TCP connection + authentication + `PingContext`. It does not run any DDL/DML.
+- For Oracle Autonomous Database or wallet-based TLS connections, additional configuration (not yet exposed via CLI flags) would be required.
+- {{< /callout >}}
+
+## Exit Codes
+| Code | Meaning                              |
+|------|--------------------------------------|
+| 0    | Connection successful.               |
+| 1    | Timed out.                           |
+| 2    | Validation error or incorrect input. |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rabbitmq/amqp091-go v1.11.0
 	github.com/segmentio/kafka-go v0.4.51
+	github.com/sijms/go-ora/v2 v2.9.0
 	go.mongodb.org/mongo-driver/v2 v2.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRb
 github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/segmentio/kafka-go v0.4.51 h1:JgDPPG75tC1rWIS2Me6MwcvXJ6f49UQ4HjAOef71Hno=
 github.com/segmentio/kafka-go v0.4.51/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
+github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
+github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/pkg/check/check-module-list.go
+++ b/pkg/check/check-module-list.go
@@ -10,6 +10,7 @@ import (
 	"wait4it/pkg/model"
 	"wait4it/pkg/mongodb"
 	"wait4it/pkg/mysql"
+	"wait4it/pkg/oracle"
 	"wait4it/pkg/postgresql"
 	"wait4it/pkg/rabbitmq"
 	"wait4it/pkg/redis"
@@ -22,6 +23,7 @@ var cm = map[string]func(c *model.CheckContext) (model.CheckInterface, error){
 	"postgres":      postgresql.NewChecker,
 	"http":          http.NewChecker,
 	"mongo":         mongodb.NewChecker,
+	"oracle":        oracle.NewChecker,
 	"redis":         redis.NewChecker,
 	"rabbitmq":      rabbitmq.NewChecker,
 	"memcached":     memcached.NewChecker,

--- a/pkg/oracle/helpers.go
+++ b/pkg/oracle/helpers.go
@@ -1,0 +1,9 @@
+package oracle
+
+import (
+	go_ora "github.com/sijms/go-ora/v2"
+)
+
+func (o OracleConnection) BuildConnectionString() string {
+	return go_ora.BuildUrl(o.Host, o.Port, o.DatabaseName, o.Username, o.Password, nil)
+}

--- a/pkg/oracle/oracle.go
+++ b/pkg/oracle/oracle.go
@@ -1,0 +1,47 @@
+package oracle
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"wait4it/pkg/model"
+
+	_ "github.com/sijms/go-ora/v2"
+)
+
+func (o *OracleConnection) BuildContext(cx model.CheckContext) {
+	o.Port = cx.Port
+	o.Host = cx.Host
+	o.Username = cx.Username
+	o.Password = cx.Password()
+	o.DatabaseName = cx.DatabaseName
+}
+
+func (o *OracleConnection) Validate() error {
+	if len(o.Host) == 0 || len(o.Username) == 0 {
+		return errors.New("host or username can't be empty")
+	}
+
+	if o.Port < 1 || o.Port > 65535 {
+		return errors.New("invalid port range for oracle")
+	}
+
+	return nil
+}
+
+func (o *OracleConnection) Check(ctx context.Context) (bool, bool, error) {
+	dsl := o.BuildConnectionString()
+
+	db, err := sql.Open("oracle", dsl)
+	if err != nil {
+		return false, true, err
+	}
+
+	err = db.PingContext(ctx)
+	if err != nil {
+		return false, false, nil
+	}
+	_ = db.Close()
+
+	return true, true, nil
+}

--- a/pkg/oracle/structs.go
+++ b/pkg/oracle/structs.go
@@ -1,0 +1,24 @@
+package oracle
+
+import (
+	"wait4it/pkg/model"
+)
+
+type OracleConnection struct {
+	Host         string
+	Port         int
+	Username     string
+	Password     string
+	DatabaseName string
+}
+
+// NewChecker creates a new checker
+func NewChecker(c *model.CheckContext) (model.CheckInterface, error) {
+	check := &OracleConnection{}
+	check.BuildContext(*c)
+	if err := check.Validate(); err != nil {
+		return nil, err
+	}
+
+	return check, nil
+}


### PR DESCRIPTION
This pull request adds support for Oracle Database connectivity checks in the project. It introduces a new Oracle check module, updates documentation, and integrates Oracle-related testing into the CI pipeline and Docker Compose setup. The most important changes are grouped below:

**Oracle Check Implementation:**

* Added a new `oracle` package with `OracleConnection` struct and methods to build connection strings, validate configuration, and check Oracle database connectivity using the `go-ora` driver. (`pkg/oracle/oracle.go`, `pkg/oracle/helpers.go`, `pkg/oracle/structs.go`) [[1]](diffhunk://#diff-823d95ce5f697c823b162dec051a1153dd3aacd2d5344da4c9a54b6f773a306dR1-R47) [[2]](diffhunk://#diff-ea6385a2be0d37b5c42bedeea0d73e857ebe372227521d4a67ff650bb37e5ba0R1-R9) [[3]](diffhunk://#diff-9d15f5f60fb370a8bd56bc684eb38f4c9ff41a236985f976cce8b5381b2b70cbR1-R24)
* Registered the Oracle checker in the check module list, enabling it as a supported type. (`pkg/check/check-module-list.go`) [[1]](diffhunk://#diff-67e167962c943ce18061fd6c68ddf03ab75821a6b36dc2f045b222fe7261b851R13) [[2]](diffhunk://#diff-67e167962c943ce18061fd6c68ddf03ab75821a6b36dc2f045b222fe7261b851R26)
* Added the `github.com/sijms/go-ora/v2` dependency for Oracle connectivity. (`go.mod`)

**Documentation Updates:**

* Added a new documentation page describing how to use the Oracle check, including environment variables, CLI arguments, and usage examples. (`docs/content/docs/Oracle/_index.md`)
* Updated the main README to include Oracle as a supported check type. (`README.md`)

**Testing and CI Integration:**

* Added Oracle and test-oracle services to `docker-compose.yaml` for local and CI testing, using the `gvenzl/oracle-free` image and a dedicated test service. (`docker-compose.yaml`)
* Integrated an Oracle test job into the GitHub Actions workflow to run automated Oracle connectivity tests. (`.github/workflows/integrations-docker.yaml`)

Closes #143 