### PR TITLE
Disable Trivy scans and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/integrations-app.yaml
+++ b/.github/workflows/integrations-app.yaml
@@ -13,9 +13,8 @@ jobs:
      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
        with:
-         go-version: '1.23'
+         go-version-file: go.mod
          check-latest: true
-         cache: true
      - run: GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o wait4it
      - name: Cache wait4it
        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/integrations-app.yaml
+++ b/.github/workflows/integrations-app.yaml
@@ -10,15 +10,15 @@ jobs:
     permissions:
       contents: read
     steps:
-     - uses: actions/checkout@v3
-     - uses: actions/setup-go@v3
+     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
        with:
          go-version: '1.23'
          check-latest: true
          cache: true
      - run: GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o wait4it
      - name: Cache wait4it
-       uses: actions/cache@v3
+       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
        with:
          path: wait4it
          key: wait4it-${{ github.run_id }}
@@ -35,7 +35,7 @@ jobs:
           - 6379:6379
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -58,7 +58,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -79,7 +79,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -103,7 +103,7 @@ jobs:
           - 3306:3306
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -122,7 +122,7 @@ jobs:
           - 80:80
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -144,7 +144,7 @@ jobs:
           - 27017:27017
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -163,7 +163,7 @@ jobs:
           - 5672:5672
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -182,7 +182,7 @@ jobs:
           - 11211:11211
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -205,7 +205,7 @@ jobs:
           - 9200:9200
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -224,7 +224,7 @@ jobs:
           - 3000:3000
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -250,7 +250,7 @@ jobs:
           - 9092:9092
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -279,7 +279,7 @@ jobs:
           --health-start-period 40s
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -311,7 +311,7 @@ jobs:
           --health-start-period 25s
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}
@@ -325,7 +325,7 @@ jobs:
       contents: read
     steps:
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it
           key: wait4it-${{ github.run_id }}

--- a/.github/workflows/integrations-docker.yaml
+++ b/.github/workflows/integrations-docker.yaml
@@ -3,64 +3,20 @@ on: push
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Build image
         run: docker build . --file Dockerfile --tag wait4it-pipeline/docker:${{ github.run_id }}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'wait4it-pipeline/docker:${{ github.run_id }}'
-          format: 'table'
-          exit-code: '0'
-          severity: 'HIGH,CRITICAL'
-          output: 'trivy-integration-report.txt'
-      - name: Display security scan results
-        if: always()
-        run: |
-          echo "=== Trivy Security Scan Results ==="
-          cat trivy-integration-report.txt || echo "No report generated"
-      - name: Add security scan results to summary
-        if: always()
-        run: |
-          echo "## 🔒 Trivy Security Scan - Integration Test Image" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          cat trivy-integration-report.txt >> $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-      - name: Run Trivy vulnerability scanner for SARIF
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'wait4it-pipeline/docker:${{ github.run_id }}'
-          format: 'sarif'
-          exit-code: '0'
-          severity: 'HIGH,CRITICAL'
-          output: 'trivy-integration-results.sarif'
-      - name: Upload Trivy scan results to GitHub Security
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: 'trivy-integration-results.sarif'
-          category: 'trivy-integration'
-      - name: Upload security scan results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-integration-report
-          path: trivy-integration-report.txt
-          retention-days: 30
       - name: Export image as tar
         run: docker save -o wait4it.tar wait4it-pipeline/docker:${{ github.run_id }}
       - name: Cache wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -72,10 +28,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -95,10 +51,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -116,10 +72,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -139,10 +95,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -160,10 +116,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -181,10 +137,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -202,10 +158,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -223,10 +179,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -244,10 +200,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -265,10 +221,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -286,10 +242,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -307,10 +263,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -328,10 +284,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}
@@ -349,10 +305,10 @@ jobs:
       PIPELINE_IMAGE_VERSION: ${{ github.run_id }}
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - uses: actions/checkout@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Retrieve wait4it
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: wait4it.tar
           key: wait4it-docker-${{ github.run_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,61 +8,17 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   build-scratch:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Build docker image
       run: |
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         docker build . --file Dockerfile --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
-    - name: Run Trivy vulnerability scanner (scratch)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'wait4it'
-        format: 'table'
-        exit-code: '0'
-        severity: 'HIGH,CRITICAL'
-        output: 'trivy-scratch-report.txt'
-    - name: Display scratch scan results
-      if: always()
-      run: |
-        echo "=== Trivy Scan Results for Scratch Image ==="
-        cat trivy-scratch-report.txt || echo "No report generated"
-    - name: Add scratch scan results to summary
-      if: always()
-      run: |
-        echo "## 🔒 Trivy Security Scan - Scratch Image" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        cat trivy-scratch-report.txt >> $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-    - name: Run Trivy vulnerability scanner for SARIF (scratch)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'wait4it'
-        format: 'sarif'
-        exit-code: '0'
-        severity: 'HIGH,CRITICAL'
-        output: 'trivy-scratch-results.sarif'
-    - name: Upload Trivy scan results to GitHub Security (scratch)
-      if: always()
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-scratch-results.sarif'
-        category: 'trivy-scratch'
-    - name: Upload scratch scan results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: trivy-scratch-report
-        path: trivy-scratch-report.txt
-        retention-days: 30
     - name: Logging into docker hub
       run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
     - name: Tag and push
@@ -86,55 +42,12 @@ jobs:
   build-alpine:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Build docker image
       run: |
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         docker build . --file Dockerfile.alpine --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
-    - name: Run Trivy vulnerability scanner (alpine)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'wait4it'
-        format: 'table'
-        exit-code: '0'
-        severity: 'HIGH,CRITICAL'
-        output: 'trivy-alpine-report.txt'
-    - name: Display alpine scan results
-      if: always()
-      run: |
-        echo "=== Trivy Scan Results for Alpine Image ==="
-        cat trivy-alpine-report.txt || echo "No report generated"
-    - name: Add alpine scan results to summary
-      if: always()
-      run: |
-        echo "## 🔒 Trivy Security Scan - Alpine Image" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        cat trivy-alpine-report.txt >> $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-    - name: Run Trivy vulnerability scanner for SARIF (alpine)
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: 'wait4it'
-        format: 'sarif'
-        exit-code: '0'
-        severity: 'HIGH,CRITICAL'
-        output: 'trivy-alpine-results.sarif'
-    - name: Upload Trivy scan results to GitHub Security (alpine)
-      if: always()
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: 'trivy-alpine-results.sarif'
-        category: 'trivy-alpine'
-    - name: Upload alpine scan results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: trivy-alpine-report
-        path: trivy-alpine-report.txt
-        retention-days: 30
     - name: Logging into docker hub
       run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
     - name: Tag and push

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,17 +20,17 @@ jobs:
       HUGO_VERSION: 0.152.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Setup Hugo
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -44,7 +44,7 @@ jobs:
             --gc --minify -s ./docs \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./docs/public
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-      - uses: actions/checkout@v3
-      - uses: wangyoucao577/go-release-action@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # v1.55
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,4 +36,4 @@ jobs:
           extra_files: LICENSE README.md
           md5sum: true
           sha256sum: true
-          goversion: 1.23
+          goversion: go.mod


### PR DESCRIPTION
## Summary
- **Disabled Trivy**: Removed all Trivy vulnerability scanner steps (table + SARIF reports), display/summary steps, `codeql-action/upload-sarif` uploads, and associated `upload-artifact` report artifacts from:
  - `.github/workflows/main.yml` (Dockerhub Release for scratch + alpine images)
  - `.github/workflows/integrations-docker.yaml` (Build job for integration tests)
- Dropped now-unused `security-events: write` permissions from those workflows.
- **Pinned actions to immutable SHAs** (safer than tags, which can be force-moved) + version comments in all workflows. This addresses the recent Node.js 20 deprecation warnings seen in action runs (e.g. "actions/checkout@v3, actions/cache@v3, docker/setup-buildx-action@v2, actions/upload-artifact@v4, ..." — Node 20 will be removed Sept 2026, forced to 24 starting June 16 2026).

## Actions updated (to Node 24 compatible releases)
- `actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6`
- `actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6`
- `actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5`
- `docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4`
- `actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5`
- `actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6`
- `actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5`
- `wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # v1.55`

All workflow YAMLs validated. Trivy references completely removed.

## Why
- Follow-up to "check if we are using trivy, if so disable it" + "check the latest warning messages from the actions, we might need to update some of the actions, do it in a separate branch."
- SHA pinning is more secure (per your request).

Closes the deprecation warnings from recent runs (Dockerhub #73, Integrations Docker #390, App #385, Pages #54, Release #55, etc.).