### PR TITLE
Add --no-banner flag to disable startup banner

### DIFF
--- a/docs/content/docs/Options/_index.md
+++ b/docs/content/docs/Options/_index.md
@@ -1,0 +1,37 @@
++++
+date = '2026-06-23T00:00:00+01:00'
+draft = false
+title = 'Options'
+weight = 20
++++
+# Global Options
+
+In addition to the per-service flags documented in the sidebar, Wait4it exposes a few global options that apply to every check. Like all flags, each one can be set either on the command line or via an environment variable (the environment variable is used when the flag is omitted).
+
+## Disable the Startup Banner (`--no-banner`)
+
+By default Wait4it prints an ASCII banner plus sponsor/support links before running a check. If you embed Wait4it in a script, CI pipeline, or a quiet startup sequence, you can suppress this output.
+
+```bash
+# Command-line flag
+wait4it --no-banner -type=tcp -h=127.0.0.1 -p=8080
+
+# Environment variable
+W4IT_NO_BANNER=true wait4it -type=tcp -h=127.0.0.1 -p=8080
+```
+
+| Flag        | Environment Variable | Description                          | Default |
+|-------------|----------------------|--------------------------------------|---------|
+| `--no-banner` | `W4IT_NO_BANNER`     | Disable the startup banner output.   | `false` |
+
+## Timeout (`-t`)
+
+The maximum time Wait4it waits for the target service to become ready, in seconds.
+
+| Flag | Environment Variable | Description                | Default |
+|------|----------------------|----------------------------|---------|
+| `-t` | `W4IT_TIMEOUT`       | Timeout in seconds.        | 30      |
+
+## Notes
+- Environment variables are read only when the corresponding flag is **not** passed on the command line.
+- See the per-service pages in the sidebar for the flags specific to each check type.

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func defaultEnvBool(env string, def bool) bool {
 
 func main() {
 	cfg := &model.CheckContext{}
+	var noBanner bool
 	flag.StringVar(&cfg.Config.CheckType, "type", defaultEnv("W4IT_TYPE", "tcp"), "define the type of check")
 	flag.IntVar(&cfg.Config.Timeout, "t", defaultEnvInt("W4IT_TIMEOUT", 30), "Timeout, amount of time wait4it waits for the port in seconds")
 	flag.StringVar(&cfg.Host, "h", defaultEnv("W4IT_HOST", "127.0.0.1"), "IP of the host you want to test against")
@@ -69,6 +70,7 @@ func main() {
 	flag.StringVar(&cfg.InfluxConf.Token, "token", defaultEnv("W4IT_INFLUX_TOKEN", ""), "InfluxDB API token")
 	flag.StringVar(&cfg.InfluxConf.Org, "org", defaultEnv("W4IT_INFLUX_ORG", ""), "InfluxDB organization name")
 	flag.StringVar(&cfg.InfluxConf.Bucket, "bucket", defaultEnv("W4IT_INFLUX_BUCKET", ""), "InfluxDB bucket name")
+	flag.BoolVar(&noBanner, "no-banner", defaultEnvBool("W4IT_NO_BANNER", false), "Disable the startup banner")
 
 	flag.Parse()
 	// We don't want to show password in help message
@@ -82,7 +84,9 @@ func main() {
 	cfg.Progress = func(s string) {
 		fmt.Print(s)
 	}
-	banner.Banner()
+	if !noBanner {
+		banner.Banner()
+	}
 	if err := check.RunCheck(context.Background(), cfg); err != nil {
 		log.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDefaultEnvBool(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		val  string
+		def  bool
+		want bool
+	}{
+		{"unset uses default", "W4IT_TEST_BOOL_UNSET", "", false, false},
+		{"default true", "W4IT_TEST_BOOL_UNSET", "", true, true},
+		{"true string", "W4IT_TEST_BOOL_TRUE", "true", false, true},
+		{"one string", "W4IT_TEST_BOOL_ONE", "1", false, true},
+		{"false string", "W4IT_TEST_BOOL_FALSE", "false", true, false},
+		{"zero string", "W4IT_TEST_BOOL_ZERO", "0", true, false},
+		{"garbage returns false", "W4IT_TEST_BOOL_GARBAGE", "garbage", false, false},
+		{"garbage returns false ignoring default", "W4IT_TEST_BOOL_GARBAGE", "garbage", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.val != "" {
+				t.Setenv(tt.env, tt.val)
+			}
+			got := defaultEnvBool(tt.env, tt.def)
+			if got != tt.want {
+				t.Fatalf("defaultEnvBool(%q, %v) = %v, want %v", tt.env, tt.def, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `--no-banner` boolean flag (default `false`) that suppresses the startup banner. It also reads the `W4IT_NO_BANNER` environment variable, consistent with every other flag in `main.go`.

## Usage

```sh
wait4it --no-banner          # CLI flag
W4IT_NO_BANNER=true wait4it  # env var
```

## Changes

- **`main.go`**: Added the `--no-banner` flag wired to `defaultEnvBool("W4IT_NO_BANNER", false)`, and wrapped the `banner.Banner()` call in `if !noBanner { ... }`.
- **`main_test.go`** (new): Unit tests for the `defaultEnvBool` helper covering unset/default, `true`/`1`/`false`/`0`, and garbage input.

## Gates

- `make test-unit` ✅
- `make lint` ✅ (0 issues)
- Integration tests unaffected (no changes to any check package logic).