### PR TITLE
Update docker image pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,78 +11,79 @@ permissions:
   packages: write
 
 jobs:
-  build-scratch:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: scratch
+            dockerfile: ./Dockerfile
+            suffix: -scratch
+            tag_latest: false
+          - variant: alpine
+            dockerfile: ./Dockerfile.alpine
+            suffix: -alpine
+            tag_latest: true
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-    - name: Build docker image
-      run: |
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        docker build . --file Dockerfile --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
-    - name: Logging into docker hub
-      run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
-    - name: Log in to GHCR
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-    - name: Tag and push
-      run: |
-        IMAGE=ph4r5h4d/wait4it
-        GHCR_IMAGE=ghcr.io/ph4r5h4d/wait4it
 
+    - name: Extract version
+      id: version
+      run: |
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo "$VERSION" | sed -e 's/^v//')
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-        echo $IMAGE
-        echo $VERSION
-
-        docker tag wait4it $IMAGE:$VERSION-scratch
-        docker tag wait4it $IMAGE:scratch
-        docker tag wait4it $GHCR_IMAGE:$VERSION-scratch
-        docker tag wait4it $GHCR_IMAGE:scratch
-
-        docker push $IMAGE:$VERSION-scratch
-        docker push $IMAGE:scratch
-        docker push $GHCR_IMAGE:$VERSION-scratch
-        docker push $GHCR_IMAGE:scratch
-
-  build-alpine:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-    - name: Build docker image
+    - name: Prepare tags
+      id: meta
       run: |
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        docker build . --file Dockerfile.alpine --label "org.opencontainers.image.revision=$VERSION" --tag wait4it
-    - name: Logging into docker hub
-      run: echo "${{ secrets.DOCKERHUBPWD }}" | docker login --username ph4r5h4d --password-stdin
+        VERSION="${{ steps.version.outputs.version }}"
+        SUFFIX="${{ matrix.suffix }}"
+        IMAGE="ph4r5h4d/wait4it"
+        GHCR_IMAGE="ghcr.io/ph4r5h4d/wait4it"
+
+        TAGS="${IMAGE}:${VERSION}${SUFFIX}"
+        TAGS="${TAGS},${IMAGE}:${{ matrix.variant }}"
+        TAGS="${TAGS},${GHCR_IMAGE}:${VERSION}${SUFFIX}"
+        TAGS="${TAGS},${GHCR_IMAGE}:${{ matrix.variant }}"
+
+        if [ "${{ matrix.tag_latest }}" = "true" ]; then
+          TAGS="${TAGS},${IMAGE}:latest"
+          TAGS="${TAGS},${GHCR_IMAGE}:latest"
+        fi
+
+        echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        username: ph4r5h4d
+        password: ${{ secrets.DOCKERHUBPWD }}
+
     - name: Log in to GHCR
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-    - name: Tag and push
-      run: |
-        IMAGE=ph4r5h4d/wait4it
-        GHCR_IMAGE=ghcr.io/ph4r5h4d/wait4it
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-        echo $IMAGE
-        echo $VERSION
-
-        docker tag wait4it $IMAGE:$VERSION-alpine
-        docker tag wait4it $IMAGE:alpine
-        docker tag wait4it $IMAGE:latest
-        docker tag wait4it $GHCR_IMAGE:$VERSION-alpine
-        docker tag wait4it $GHCR_IMAGE:alpine
-        docker tag wait4it $GHCR_IMAGE:latest
-
-        docker push $IMAGE:$VERSION-alpine
-        docker push $IMAGE:alpine
-        docker push $IMAGE:latest
-        docker push $GHCR_IMAGE:$VERSION-alpine
-        docker push $GHCR_IMAGE:alpine
-        docker push $GHCR_IMAGE:latest
+    - name: Build and push (${{ matrix.variant }})
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      with:
+        context: .
+        file: ${{ matrix.dockerfile }}
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: org.opencontainers.image.revision=${{ steps.version.outputs.version }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,10 @@ Common targets:
 | `make test` | Alias for `test-unit` |
 | `make lint` | Run `golangci-lint` |
 | `make coverage` | Generate HTML coverage report in `coverage/` |
-| `make docker-build` | Build the default (scratch) Docker image |
-| `make docker-build-alpine` | Build the Alpine Docker image |
+| `make docker-build` | Build the default (scratch) Docker image (native arch, load locally) |
+| `make docker-build-alpine` | Build the Alpine Docker image (native arch, load locally) |
+| `make docker-build-multiarch` | Build multi-arch (amd64, arm64, arm/v7) scratch image (requires `--push`) |
+| `make docker-build-multiarch-alpine` | Build multi-arch Alpine image (requires `--push`) |
 | `make clean` | Remove the binary and coverage artifacts |
 | `make help` | List all targets |
 
@@ -136,8 +138,15 @@ here, rather than working around it with one-off commands.
   `lint`, `unit-test`, and `integration-test` jobs. Local `make` targets must match
   these jobs.
 - **Docker Release** (`.github/workflows/main.yml`): triggered by `v*` tags; builds and
-  publishes scratch and alpine images to Docker Hub and GHCR.
-- Keep workflow action versions pinned (the repo uses SHA-pinned actions).
+  publishes **multi-arch** (linux/amd64, linux/arm64, linux/arm/v7) scratch and alpine
+  images to Docker Hub and GHCR. Uses `docker/setup-qemu-action`,
+  `docker/setup-buildx-action`, `docker/login-action`, and `docker/build-push-action`
+  with a matrix strategy. The Go builder stage runs natively on the runner
+  (`--platform=$BUILDPLATFORM`) and cross-compiles to the target arch via
+  `TARGETOS`/`TARGETARCH`/`TARGETVARIANT` build args (no QEMU emulation for the Go
+  compiler).
+- Keep workflow action versions pinned (the repo uses **full 40-character long SHA**
+  pinned actions with version comments, e.g. `actions/checkout@<sha> # v6`).
 
 ## Dependencies & tooling
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.25-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+ARG TARGETOS TARGETARCH TARGETVARIANT
 RUN apk update && apk add --no-cache gcc git
 
 ENV USER=appuser
@@ -16,7 +17,7 @@ WORKDIR $GOPATH/src/github.com/ph4r5h4d/wait4it
 COPY . .
 RUN go mod download
 RUN go mod verify
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/wait4it
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} go build -ldflags="-w -s" -o /go/bin/wait4it
 RUN chown appuser:appuser /go/bin/wait4it
 
 FROM scratch

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,12 +1,13 @@
-FROM golang:1.25-alpine as build-env
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build-env
+ARG TARGETOS TARGETARCH TARGETVARIANT
 RUN apk add git gcc
 RUN mkdir /app
 WORKDIR /app
 COPY . .
 RUN go mod download
 RUN go mod verify
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o wait4it
-FROM alpine:3.17
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} go build -ldflags="-w -s" -o wait4it
+FROM alpine:3.22
 LABEL org.opencontainers.image.source="https://github.com/ph4r5h4d/wait4it"
 COPY --from=build-env /app/wait4it .
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ COVERAGE_OUT    := $(COVERAGE_DIR)/coverage.out
 # Docker parameters
 DOCKER_IMAGE := wait4it
 
-.PHONY: all build run clean test test-unit test-integration test-all lint coverage docker-build docker-build-alpine help
+.PHONY: all build run clean test test-unit test-integration test-all lint coverage docker-build docker-build-alpine docker-build-multiarch docker-build-multiarch-alpine help
 
 ## all: Build the binary (default target)
 all: build
@@ -60,13 +60,21 @@ coverage:
 	$(GO) tool cover -html=$(COVERAGE_OUT) -o $(COVERAGE_DIR)/coverage.html
 	@echo "Coverage report: $(COVERAGE_DIR)/coverage.html"
 
-## docker-build: Build Docker image
+## docker-build: Build Docker image (native arch, load locally)
 docker-build:
-	docker build -t $(DOCKER_IMAGE) .
+	docker buildx build --load -t $(DOCKER_IMAGE) .
 
-## docker-build-alpine: Build Alpine Docker image
+## docker-build-alpine: Build Alpine Docker image (native arch, load locally)
 docker-build-alpine:
-	docker build -f Dockerfile.alpine -t $(DOCKER_IMAGE):alpine .
+	docker buildx build --load -f Dockerfile.alpine -t $(DOCKER_IMAGE):alpine .
+
+## docker-build-multiarch: Build multi-arch Docker images (requires --push to a registry)
+docker-build-multiarch:
+	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t $(DOCKER_IMAGE) .
+
+## docker-build-multiarch-alpine: Build multi-arch Alpine Docker images (requires --push to a registry)
+docker-build-multiarch-alpine:
+	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f Dockerfile.alpine -t $(DOCKER_IMAGE):alpine .
 
 ## help: Show this help message
 help:


### PR DESCRIPTION
This pull request introduces multi-architecture (multi-arch) Docker image support for both the scratch and Alpine builds, updates the build pipeline to use a matrix strategy, and improves documentation and Makefile targets to reflect these changes. The Dockerfiles are updated to support cross-compilation using build arguments, and the workflow now pushes images for multiple platforms to Docker Hub and GHCR.

**Multi-arch Docker support and build pipeline updates:**

- **GitHub Actions workflow modernization:** The `build` job in `.github/workflows/main.yml` now uses a matrix strategy to build and push both scratch and Alpine images for multiple architectures (`linux/amd64`, `linux/arm64`, `linux/arm/v7`). It replaces the previous separate jobs with a single, more maintainable job, and switches to using official Docker actions for build, login, and QEMU setup.
- **Dockerfile cross-compilation:** Both `Dockerfile` and `Dockerfile.alpine` are updated to support cross-compilation by using `--platform=$BUILDPLATFORM` and setting `GOOS`, `GOARCH`, and `GOARM` build arguments, enabling builds for multiple architectures in one pipeline. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R2) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L19-R20) [[3]](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL1-R10)

**Makefile and documentation improvements:**

- **New Makefile targets for multi-arch builds:** The `Makefile` adds `docker-build-multiarch` and `docker-build-multiarch-alpine` targets for building and pushing multi-arch images, and updates existing Docker build targets to use `docker buildx`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L19-R19) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L63-R77)
- **Documentation updates:** `AGENTS.md` is updated to describe the new multi-arch build targets, explain the workflow's matrix strategy and cross-compilation approach, and clarify the use of SHA-pinned GitHub Actions. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L102-R105) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L139-R149)